### PR TITLE
Handover changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ This README contains information on working with the back end code. For higher l
 
 The back end consists of two parts; a sync engine and an API server to control it. To run either you first need to define the environment variables listed under [Configuration](#configuration).
 
+## Docker compose version
+We're using docker-compose specification **V1**.
+docker-compose **1.29.2** recommened.
+The extended shell style features used in docker-compose.yml might not be supported on older versions of docker-compose.
+
+## Python version
+We use features added to Python after **3.8.10**
+**3.10.5** is currently running in production containers and works in local development environment as well.
+
 ## Run without Docker (not for production)
 
 Start Postgres:
@@ -59,6 +68,8 @@ te-canvas is configured using the following environment variables.
 | `TE_CERT`            | TimeEdit SOAP API certificate.                   |                                    |
 | `TE_USERNAME`        | TimeEdit username.                               |                                    |
 | `TE_PASSWORD`        | TimeEdit password.                               |                                    |
+| `TE_GENERAL_ID_FIELD`        | TimeEdit general id field, defaults to `general.id`.                               |          ✅                           |
+| `TE_GENERAL_TITLE_FIELD`        | TimeEdit general title field, defaults to `general.title`.                              |                                  ✅  | 
 |                      |                                                  |                                    |
 | `CANVAS_URL`         | URL of Canvas instance.                          |                                    |
 | `CANVAS_KEY`         | Canvas API key.                                  |                                    |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,8 @@ services:
       - TE_CERT
       - TE_USERNAME
       - TE_PASSWORD
+      - TE_GENERAL_ID_FIELD-general.title
+      - TE_GENERAL_TITLE_FIELD-general.id
 
       - CANVAS_URL
       - CANVAS_KEY

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,3 +1,4 @@
+wheel
 Flask==2.1.2
 flask-cors
 flask-restx

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,4 +1,4 @@
-Flask
+Flask==2.1.2
 flask-cors
 flask-restx
 canvasapi

--- a/te_canvas/timeedit.py
+++ b/te_canvas/timeedit.py
@@ -18,6 +18,10 @@ class TimeEdit:
             cert = os.environ["TE_CERT"]
             username = os.environ["TE_USERNAME"]
             password = os.environ["TE_PASSWORD"]
+
+            # We need this since not all timeedit instances use the same field
+            self.te_general_id_field = os.environ["TE_GENERAL_ID_FIELD"]
+            self.te_general_title_field = os.environ["TE_GENERAL_TITLE_FIELD"]
         except Exception as e:
             logger.critical(f"Missing env var: {e}")
             sys.exit(1)
@@ -59,9 +63,15 @@ class TimeEdit:
             type=type,
             numberofobjects=number_of_objects,
             beginindex=begin_index,
-            generalsearchfields={"field": ["general.id", "general.title"]},
+            generalsearchfields={"field": [
+                self.te_general_id_field,
+                self.te_general_title_field
+            ]},
             generalsearchstring=search_string,
-            returnfields=["general.id", "general.title"],
+            returnfields=[
+                self.te_general_id_field,
+                self.te_general_title_field
+            ],
         )
         if resp.objects is None:
             # Can't really warn about this generally since this endpoint is used for searching.
@@ -75,7 +85,7 @@ class TimeEdit:
             login=self.login,
             type=type,
             numberofobjects=1,
-            generalsearchfields={"field": ["general.id", "general.title"]},
+            generalsearchfields={"field": [self.te_general_id_field, self.te_general_title_field]},
             generalsearchstring=search_string,
         ).totalnumberofobjects
 


### PR DESCRIPTION
use env variables for general.id and general.title in timeedit
this is because some timeedit instances use general.id_ref and general.title_ref