### PR TITLE
feat: group and default template config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     environment:
       - TE_ID
       - TE_USERGROUP
-      - TE_RETURN_FIELDS=${TE_RETURN_FIELDS-general.id,general.title}
+      - TE_RETURN_FIELDS=${TE_RETURN_FIELDS-general.id}
       - TE_SEARCH_FIELDS=${TE_SEARCH_FIELDS-general.id,general.title}
 
       - TE_CERT
@@ -65,7 +65,7 @@ services:
       - TE_CERT
       - TE_USERNAME
       - TE_PASSWORD
-      - TE_RETURN_FIELDS=${TE_RETURN_FIELDS-general.id,general.title}
+      - TE_RETURN_FIELDS=${TE_RETURN_FIELDS-general.id}
       - TE_SEARCH_FIELDS=${TE_SEARCH_FIELDS-general.id,general.title}
 
       - CANVAS_URL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,8 +36,8 @@ services:
     environment:
       - TE_ID
       - TE_USERGROUP
-      - TE_GENERAL_ID_FIELD=${TE_GENERAL_ID_FIELD-general.title}
-      - TE_GENERAL_TITLE_FIELD=${TE_GENERAL_TITLE_FIELD-general.id}
+      - TE_RETURN_FIELDS=${TE_RETURN_FIELDS-general.id,general.title}
+      - TE_SEARCH_FIELDS=${TE_RETURN_FIELDS-general.id,general.title}
 
       - TE_CERT
       - TE_USERNAME
@@ -65,8 +65,8 @@ services:
       - TE_CERT
       - TE_USERNAME
       - TE_PASSWORD
-      - TE_GENERAL_ID_FIELD=${TE_GENERAL_ID_FIELD-general.title}
-      - TE_GENERAL_TITLE_FIELD=${TE_GENERAL_TITLE_FIELD-general.id}
+      - TE_RETURN_FIELDS=${TE_RETURN_FIELDS-general.id,general.title}
+      - TE_SEARCH_FIELDS=${TE_RETURN_FIELDS-general.id,general.title}
 
       - CANVAS_URL
       - CANVAS_KEY

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       - TE_ID
       - TE_USERGROUP
       - TE_RETURN_FIELDS=${TE_RETURN_FIELDS-general.id,general.title}
-      - TE_SEARCH_FIELDS=${TE_RETURN_FIELDS-general.id,general.title}
+      - TE_SEARCH_FIELDS=${TE_SEARCH_FIELDS-general.id,general.title}
 
       - TE_CERT
       - TE_USERNAME
@@ -66,7 +66,7 @@ services:
       - TE_USERNAME
       - TE_PASSWORD
       - TE_RETURN_FIELDS=${TE_RETURN_FIELDS-general.id,general.title}
-      - TE_SEARCH_FIELDS=${TE_RETURN_FIELDS-general.id,general.title}
+      - TE_SEARCH_FIELDS=${TE_SEARCH_FIELDS-general.id,general.title}
 
       - CANVAS_URL
       - CANVAS_KEY

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,8 @@ services:
     environment:
       - TE_ID
       - TE_USERGROUP
+      - TE_GENERAL_ID_FIELD=${TE_GENERAL_ID_FIELD-general.title}
+      - TE_GENERAL_TITLE_FIELD=${TE_GENERAL_TITLE_FIELD-general.id}
 
       - TE_CERT
       - TE_USERNAME
@@ -63,8 +65,8 @@ services:
       - TE_CERT
       - TE_USERNAME
       - TE_PASSWORD
-      - TE_GENERAL_ID_FIELD-general.title
-      - TE_GENERAL_TITLE_FIELD-general.id
+      - TE_GENERAL_ID_FIELD=${TE_GENERAL_ID_FIELD-general.title}
+      - TE_GENERAL_TITLE_FIELD=${TE_GENERAL_TITLE_FIELD-general.id}
 
       - CANVAS_URL
       - CANVAS_KEY

--- a/generate-docs.sh
+++ b/generate-docs.sh
@@ -24,7 +24,6 @@ te_canvas.test.test_timeedit \
 te_canvas.test.test_translator \
 te_canvas.timeedit \
 te_canvas.translator \
-te_canvas.util
 
 mkdir -p docs
 mv te_canvas*.html docs

--- a/te_canvas/api.py
+++ b/te_canvas/api.py
@@ -61,6 +61,7 @@ def create_app(db: DB = None, timeedit: TimeEdit = None, canvas: Canvas = None) 
     # --- Config ---------------------------------------------------------------
 
     config_api.ns.add_resource(config_api.Template, "/template", resource_class_kwargs={"db": db})
+    config_api.ns.add_resource(config_api.Ok, "/ok", resource_class_kwargs={"db": db})
     api.add_namespace(config_api.ns)
 
     return flask

--- a/te_canvas/api_ns/config.py
+++ b/te_canvas/api_ns/config.py
@@ -6,6 +6,23 @@ from sqlalchemy.exc import NoResultFound  # type: ignore
 ns = Namespace("config", description="Config API", prefix="/api")
 
 
+class Ok(Resource):
+    def __init__(self, api=None, *args, **kwargs):
+        super().__init__(api, args, kwargs)
+        self.db = kwargs["db"]
+
+    get_parser = reqparse.RequestParser()
+    get_parser.add_argument("canvas_group", type=str, required=True)
+
+    @ns.param("canvas_group", "Canvas group")
+    def get(self):
+        args = self.get_parser.parse_args(strict=True)
+        res = self.db.get_template_config()
+        default = set(n for [_, n, _, _, c] in res if c == "default")
+        group = set(n for [_, n, _, _, c] in res if c == args.canvas_group)
+        return {"group": [n for n in group], "default": [n for n in default]}
+
+
 class Template(Resource):
     def __init__(self, api=None, *args, **kwargs):
         super().__init__(api, args, kwargs)

--- a/te_canvas/api_ns/timeedit.py
+++ b/te_canvas/api_ns/timeedit.py
@@ -1,6 +1,7 @@
 from flask_restx import Namespace, Resource, reqparse
 
 import te_canvas.log as log
+from te_canvas.timeedit import TimeEdit
 
 logger = log.get_logger()
 
@@ -69,7 +70,7 @@ class Types(Resource):
 class Fields(Resource):
     def __init__(self, api=None, *args, **kwargs):
         super().__init__(api, args, kwargs)
-        self.timeedit = kwargs["timeedit"]
+        self.timeedit: TimeEdit = kwargs["timeedit"]
 
     parser = reqparse.RequestParser()
     parser.add_argument("extid", type=str, required=True)
@@ -77,8 +78,7 @@ class Fields(Resource):
     @ns.param("extid", "External id.")
     def get(self):
         args = self.parser.parse_args(strict=True)
-        extid = args["extid"]
-        res = self.timeedit.find_object_fields(extid)
+        res = self.timeedit.find_object_fields(args["extid"])
         if res is None:
-            return {"message": f"Object {extid} not found"}, 404
+            return {"message": f"Object {args['extid']} not found"}, 404
         return res

--- a/te_canvas/sync.py
+++ b/te_canvas/sync.py
@@ -197,10 +197,19 @@ class Syncer:
             self.logger.info("%s: Deleted %s events", canvas_group, len(deleted))
 
             # Delete flagged connections
-            session.query(Connection).filter(
-                Connection.canvas_group == canvas_group,
-                Connection.delete_flag is True,
-            ).delete()
+            deleted_flagged_count = (
+                session.query(Connection)
+                .filter(
+                    Connection.canvas_group == canvas_group,
+                    Connection.delete_flag == "t",
+                )
+                .delete()
+            )
+            self.logger.info(
+                "%s: Deleted %s flagged connections",
+                canvas_group,
+                deleted_flagged_count,
+            )
 
             # Push to Canvas and add to database
             te_groups = flat_list(

--- a/te_canvas/sync.py
+++ b/te_canvas/sync.py
@@ -13,7 +13,7 @@ from te_canvas.db import DB, Connection, flat_list
 from te_canvas.log import get_logger
 from te_canvas.timeedit import TimeEdit
 from te_canvas.translator import TemplateError, Translator
-from te_canvas.util import TemplateConfigState
+from te_canvas.types.sync_state import SyncState
 
 
 class Syncer:
@@ -71,7 +71,7 @@ class Syncer:
         try:
             self.max_workers = int(os.environ["MAX_WORKERS"])
         except Exception as e:
-            self.logger.critical(f"Missing env var: {e}")
+            self.logger.critical("Missing env var: %s", e)
             sys.exit(1)
 
         self.db = db or DB()
@@ -79,12 +79,12 @@ class Syncer:
         self.timeedit = timeedit or TimeEdit()
 
         # Mapping canvas_group to in-memory State:s
-        self.states: dict[str, TemplateConfigState] = {}
+        self.states: dict[str, SyncState] = {}
 
         # Set to false at start of each sync, set to true at completion
         self.sync_complete: dict[str, bool] = {}
 
-    def __state_te(self, canvas_group: str) -> TemplateConfigState:
+    def __state_te(self, canvas_group: str) -> SyncState:
         """
         Get the TimeEdit state relevant for canvas_group. Number comments reference "modifications
         to detect", see class docstring.
@@ -115,7 +115,7 @@ class Syncer:
                 "te_event_modify_date": te_event_modify_date,
             }
 
-    def __state_canvas(self, canvas_group: str) -> TemplateConfigState:
+    def __state_canvas(self, canvas_group: str) -> SyncState:
         """
         Get the Canvas state relevant for canvas_group. Number comments reference "modifications to
         detect", see class docstring.
@@ -134,7 +134,7 @@ class Syncer:
             "canvas_event_modify_date": canvas_event_modify_date,
         }
 
-    def __has_changed(self, prev_state: Optional[TemplateConfigState], state: TemplateConfigState) -> bool:
+    def __has_changed(self, prev_state: Optional[SyncState], state: SyncState) -> bool:
         return state != prev_state
 
     def sync_all(self):
@@ -153,7 +153,9 @@ class Syncer:
             res = list(executor.map(self.sync_one, groups))
 
         self.logger.info(
-            f"Sync job completed; {len([x for x in res if x])} Canvas groups synced; {len([x for x in res if not x])} skipped"
+            "Sync job completed: %s Canvas groups synced:  %s skipped",
+            len([x for x in res if x]),
+            len([x for x in res if not x]),
         )
 
     def sync_one(self, canvas_group: str) -> bool:
@@ -177,25 +179,27 @@ class Syncer:
 
             # Change detection
             prev_state = self.states.get(canvas_group)
-            new_state = self.__state_te(canvas_group) | self.__state_canvas(canvas_group) | translator.state()
+            new_state = (
+                self.__state_te(canvas_group) | self.__state_canvas(canvas_group) | translator.get_state(canvas_group)
+            )
             self.states[canvas_group] = new_state
             self.logger.debug("State: %s", new_state)
 
             if not self.__has_changed(prev_state, new_state) and self.sync_complete.get(canvas_group, False):
-                self.logger.info(f"{canvas_group}: Nothing changed, skipping")
+                self.logger.info("%s: Nothing changed, skipping", canvas_group)
                 return False
 
             self.sync_complete[canvas_group] = False
 
             # Remove all events previously added by us to this Canvas group
-            self.logger.info(f"{canvas_group}: Deleting events")
+            self.logger.info("%s: Deleting events", canvas_group)
             deleted = self.canvas.delete_events(int(canvas_group))
-            self.logger.info(f"{canvas_group}: Deleted {len(deleted)} events")
+            self.logger.info("%s: Deleted %s events", canvas_group, len(deleted))
 
             # Delete flagged connections
             session.query(Connection).filter(
                 Connection.canvas_group == canvas_group,
-                Connection.delete_flag == True,
+                Connection.delete_flag is True,
             ).delete()
 
             # Push to Canvas and add to database
@@ -205,11 +209,18 @@ class Syncer:
                 .order_by(Connection.canvas_group, Connection.te_group)
             )
 
-            reservations = self.timeedit.find_reservations_all(te_groups, translator.return_types)
+            reservations = self.timeedit.find_reservations_all(te_groups, translator.get_return_types(canvas_group))
 
-            self.logger.info(f"{canvas_group}: Adding events: {te_groups} ({len(reservations)} events)")
+            self.logger.info(
+                "%s: Adding events: %s (%s events)",
+                canvas_group,
+                te_groups,
+                len(reservations),
+            )
             for r in reservations:
-                self.canvas.create_event(translator.canvas_event(r) | {"context_code": f"course_{canvas_group}"})
+                self.canvas.create_event(
+                    translator.canvas_event(r, canvas_group) | {"context_code": f"course_{canvas_group}"}
+                )
 
             # Record new Canvas state
             #
@@ -252,7 +263,7 @@ class JobScheduler(object):
         return self.scheduler.shutdown()
 
     def add(self, func, seconds, kwargs):
-        self.logger.info(f"Adding job to scheduler: interval={seconds}")
+        self.logger.info("Adding job to scheduler: interval=%s", seconds)
         return self.scheduler.add_job(
             func,
             "interval",

--- a/te_canvas/translator.py
+++ b/te_canvas/translator.py
@@ -4,7 +4,10 @@ with templates related to this.
 """
 
 from te_canvas.db import DB
-from te_canvas.util import TemplateConfigState
+from te_canvas.types.config_type import ConfigType
+from te_canvas.types.sync_state import SyncState
+from te_canvas.types.template_config import TemplateConfig
+from te_canvas.types.template_return_types import TemplateReturnTypes
 
 # Used to differentiate te-canvas events from manually added Canvas events, this string is added as
 # a suffix to each event title. These are zero-width spaces, an invisible unicode character. We use
@@ -25,68 +28,143 @@ class Translator:
     """
     Translator creates Canvas events from TimeEdit events based on a set of template strings.
 
-    Template strings are read from the database only at Translator initialization. So for any given
+    Template configuration are read from the database only at Translator initialization. So for any given
     Translator instance t, t.canvas_event is a pure function.
     """
 
     def __init__(self, db: DB, timeedit):
         """
-        Read template strings from the database and extract fields (used for template functionality)
+        Read template configuration from the database and extract fields (used for template functionality)
         and return types (used as arguments in TimeEdit API calls).
 
         Raises:
-            TemplateError, if any of the required template strings (title, location, description) is
-            missing or empty.
+            TemplateError, if no valid group or default template config.
         """
         self.db = db
         self.timeedit = timeedit
-        template = self.__get_template_config()
-        self.template_title = self.__extract_template(template, "title")
-        self.template_location = self.__extract_template(template, "location")
-        self.template_description = self.__extract_template(template, "description")
-        self.return_types = self.__extract_return_types(template)
+        template_data = self.__get_template_config()
+        self.templates = self.__create_templates(template_data)
+        self.return_types = self.__create_return_types(self.templates)
 
-    def __extract_template(self, template, name: str) -> "list[dict[str, str]]":
+    def __create_templates(self, template) -> dict[str, TemplateConfig]:
         """
-        Extract template from db query.
+        Create templates from db query.
 
         Used for translating timeedit reservations.
         """
-        return [{t: f} for (_, n, t, f, _) in template if n == name]
+        groups_with_config = set(cg for (_, _, _, _, cg) in template)
+        # All groups with atleast one config entry.
+        groups = {
+            cg: {
+                ConfigType.TITLE.value: [],
+                ConfigType.LOCATION.value: [],
+                ConfigType.DESCRIPTION.value: [],
+            }
+            for cg in groups_with_config
+        }
+        for _, ct, t, f, cg in template:
+            groups[cg][ct].append({t: f})
+        # Filter out groups without valid config.
+        return {
+            key: groups[key] for key in groups.keys() if self.__is_valid(groups[key])
+        }
 
-    def __extract_return_types(self, template) -> "dict[str, list[str]]":
+    def __is_valid(self, template: TemplateConfig) -> bool:
         """
-        Extract return types from db query.
+        Valid template config must have atleast one entry of each config_type.
+        """
+        config_types = set(ct for ct, entries in template.items() if len(entries) > 0)
+        return len(config_types) == 3
+
+    def __create_return_types(
+        self,
+        templates: dict[str, TemplateConfig],
+    ) -> dict[str, TemplateReturnTypes]:
+        """
+        Create return types.
 
         Used in API call to timeedit when getting reservations.
         """
-        te_types = set(t for (_, _, t, _, _) in template)
-        return {te_type: [f for (_, _, t, f, _) in template if t == te_type] for te_type in te_types}
+        return_types = {}
+        for key in templates.keys():
+            return_types[key] = self.__extract_fields(templates[key])
+        return return_types
 
-    def canvas_event(self, timeedit_reservation: dict) -> "dict[str,str]":
+    def __extract_fields(self, template: TemplateConfig) -> TemplateReturnTypes:
+        """
+        Extract unique te_type:te_field combinations.
+        Disregard config_type since it's not a timeedit concept.
+        """
+        te_types = set(
+            te_type
+            for ct in template.values()
+            for entry in ct
+            for te_type, _ in entry.items()
+        )
+        return_types = {
+            te_type: [
+                f
+                for entries in template.values()
+                for e in entries
+                for t, f in e.items()
+                if t == te_type
+            ]
+            for te_type in te_types
+        }
+        return {
+            te_type: list(dict.fromkeys(te_fields))
+            for te_type, te_fields in return_types.items()
+        }
+
+    def get_return_types(self, canvas_group: str) -> TemplateReturnTypes:
+        if canvas_group in self.return_types:
+            return self.return_types[canvas_group]
+        if "default" in self.return_types:
+            return self.return_types["default"]
+        raise TemplateError
+
+    def canvas_event(
+        self, timeedit_reservation: dict, canvas_group: str
+    ) -> "dict[str,str]":
         """
         Create canvas event from timeedit reservations.
         """
         return {
-            "title":         self.__translate_fields(self.template_title, timeedit_reservation["objects"], TITLE_SEPARATOR) + TAG_TITLE,
-            "location_name": self.__translate_fields(self.template_location, timeedit_reservation["objects"], LOCATION_SEPARATOR),
-            "description":   self.__translate_fields(self.template_description, timeedit_reservation["objects"], DESCRIPTION_SEPARATOR)
+            "title":         self.__translate_fields(canvas_group, ConfigType.TITLE.value,timeedit_reservation["objects"], TITLE_SEPARATOR) + TAG_TITLE,
+            "location_name": self.__translate_fields(canvas_group, ConfigType.LOCATION.value, timeedit_reservation["objects"], LOCATION_SEPARATOR),
+            "description":   self.__translate_fields(canvas_group, ConfigType.DESCRIPTION.value, timeedit_reservation["objects"], DESCRIPTION_SEPARATOR)
                 + f'<br><br><a href="{self.timeedit.reservation_url(timeedit_reservation["id"])}">Edit on TimeEdit</a>',
             "start_at": timeedit_reservation["start_at"],
             "end_at":   timeedit_reservation["end_at"],
             }  # fmt: skip
 
-    def state(self) -> TemplateConfigState:
+    def get_state(self, canvas_group: str) -> SyncState:
         """
         Return an object allowing instances of Translator to be compared.
 
         Used for change detection in sync.py.
         """
-        return {
-            "title": self.template_title,
-            "location": self.template_location,
-            "description": self.template_description,
-        }
+        state = {}
+        if "default" in self.templates:
+            state["default"] = "".join(
+                [
+                    "".join([ct, t, f])
+                    for ct in self.templates["default"].keys()
+                    for entry in self.templates["default"][ct]
+                    for t, f in entry.items()
+                ]
+            )
+
+        if canvas_group in self.templates:
+            state[canvas_group] = "".join(
+                [
+                    "".join([ct, t, f])
+                    for ct in self.templates[canvas_group].keys()
+                    for entry in self.templates[canvas_group][ct]
+                    for t, f in entry.items()
+                ]
+            )
+        return state
 
     def __get_template_config(self):
         """
@@ -101,14 +179,21 @@ class Translator:
             raise TemplateError
         return res
 
-    def __translate_fields(self, template: "list[dict[str,str]]", objects: "list[dict]", separator: str) -> str:
+    def __translate_fields(
+        self, canvas_group: str, config_type: str, objects: "list[dict]", separator: str
+    ) -> str:
         """
         Used for translating fields from te reservations according to template.
         """
+        template_config = (
+            self.templates[canvas_group]
+            if canvas_group in self.templates.keys()
+            else self.templates["default"]
+        )
         selected_fields = []
         for o in objects:
             te_type = o["type"]
             for te_field, content in o["fields"].items():
-                if {te_type: te_field} in template:
+                if {te_type: te_field} in template_config[config_type]:
                     selected_fields.append(content)
         return separator.join(selected_fields)

--- a/te_canvas/translator.py
+++ b/te_canvas/translator.py
@@ -65,9 +65,7 @@ class Translator:
         for _, ct, t, f, cg in template:
             groups[cg][ct].append({t: f})
         # Filter out groups without valid config.
-        return {
-            key: groups[key] for key in groups.keys() if self.__is_valid(groups[key])
-        }
+        return {key: groups[key] for key in groups.keys() if self.__is_valid(groups[key])}
 
     def __is_valid(self, template: TemplateConfig) -> bool:
         """
@@ -95,26 +93,12 @@ class Translator:
         Extract unique te_type:te_field combinations.
         Disregard config_type since it's not a timeedit concept.
         """
-        te_types = set(
-            te_type
-            for ct in template.values()
-            for entry in ct
-            for te_type, _ in entry.items()
-        )
+        te_types = set(te_type for ct in template.values() for entry in ct for te_type, _ in entry.items())
         return_types = {
-            te_type: [
-                f
-                for entries in template.values()
-                for e in entries
-                for t, f in e.items()
-                if t == te_type
-            ]
+            te_type: [f for entries in template.values() for e in entries for t, f in e.items() if t == te_type]
             for te_type in te_types
         }
-        return {
-            te_type: list(dict.fromkeys(te_fields))
-            for te_type, te_fields in return_types.items()
-        }
+        return {te_type: list(dict.fromkeys(te_fields)) for te_type, te_fields in return_types.items()}
 
     def get_return_types(self, canvas_group: str) -> TemplateReturnTypes:
         if canvas_group in self.return_types:
@@ -123,9 +107,7 @@ class Translator:
             return self.return_types["default"]
         raise TemplateError
 
-    def canvas_event(
-        self, timeedit_reservation: dict, canvas_group: str
-    ) -> "dict[str,str]":
+    def canvas_event(self, timeedit_reservation: dict, canvas_group: str) -> "dict[str,str]":
         """
         Create canvas event from timeedit reservations.
         """
@@ -179,16 +161,12 @@ class Translator:
             raise TemplateError
         return res
 
-    def __translate_fields(
-        self, canvas_group: str, config_type: str, objects: "list[dict]", separator: str
-    ) -> str:
+    def __translate_fields(self, canvas_group: str, config_type: str, objects: "list[dict]", separator: str) -> str:
         """
         Used for translating fields from te reservations according to template.
         """
         template_config = (
-            self.templates[canvas_group]
-            if canvas_group in self.templates.keys()
-            else self.templates["default"]
+            self.templates[canvas_group] if canvas_group in self.templates.keys() else self.templates["default"]
         )
         selected_fields = []
         for o in objects:

--- a/te_canvas/types/config_type.py
+++ b/te_canvas/types/config_type.py
@@ -1,0 +1,11 @@
+from enum import Enum
+
+
+class ConfigType(Enum):
+    """
+    The three different types of template configuration that exist.
+    """
+
+    TITLE = "title"
+    LOCATION = "location"
+    DESCRIPTION = "description"

--- a/te_canvas/types/sync_state.py
+++ b/te_canvas/types/sync_state.py
@@ -1,0 +1,1 @@
+SyncState = dict[str, str]

--- a/te_canvas/types/template_config.py
+++ b/te_canvas/types/template_config.py
@@ -1,0 +1,1 @@
+TemplateConfig = dict[str, list[dict[str, str]]]

--- a/te_canvas/types/template_return_types.py
+++ b/te_canvas/types/template_return_types.py
@@ -1,0 +1,1 @@
+TemplateReturnTypes = dict[str, list[str]]

--- a/te_canvas/util.py
+++ b/te_canvas/util.py
@@ -1,1 +1,0 @@
-TemplateConfigState = dict[str, list[dict[str, str]]]


### PR DESCRIPTION
This PR will add support for group and default template config.
If a group does not have its own valid config, it will fall back on default config.

It also changes abstraction level for search and return type fields in timeedit.py
Now, we don't make assumptions about what fields will be available and mandatory.
Default is set to what seems to be the most common across TE instances.
Then we override with env var when we have to.