### PR TITLE
build: add title field

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     environment:
       - TE_ID
       - TE_USERGROUP
-      - TE_RETURN_FIELDS=${TE_RETURN_FIELDS-general.id}
+      - TE_RETURN_FIELDS=${TE_RETURN_FIELDS-general.id,general.title}
       - TE_SEARCH_FIELDS=${TE_SEARCH_FIELDS-general.id,general.title}
 
       - TE_CERT
@@ -65,7 +65,7 @@ services:
       - TE_CERT
       - TE_USERNAME
       - TE_PASSWORD
-      - TE_RETURN_FIELDS=${TE_RETURN_FIELDS-general.id}
+      - TE_RETURN_FIELDS=${TE_RETURN_FIELDS-general.id,general.title}
       - TE_SEARCH_FIELDS=${TE_SEARCH_FIELDS-general.id,general.title}
 
       - CANVAS_URL


### PR DESCRIPTION
general.id has found to be missing in some TE instances.
but general.title has always been mandatory.
add it to env vars in docker-compose