### PR TITLE
fix: truncate title

### DIFF
--- a/te_canvas/db.py
+++ b/te_canvas/db.py
@@ -190,14 +190,24 @@ class DB:
 
     def add_template_config(self, config_type: str, te_type: str, te_field: str, canvas_group: Optional[str]):
         with self.sqla_session() as session:
-            existing_row = session.execute(
-                select(TemplateConfig)
-                .where(TemplateConfig.config_type == config_type)
-                .where(TemplateConfig.te_type == te_type)
-                .where(TemplateConfig.te_field == te_field)
-                .where(TemplateConfig.canvas_group == canvas_group)
-            ).first()
-            if existing_row is None:
+            duplicate_check = (
+                session.execute(
+                    select(TemplateConfig)
+                    .where(TemplateConfig.config_type == config_type)
+                    .where(TemplateConfig.te_type == te_type)
+                    .where(TemplateConfig.te_field == te_field)
+                    .where(TemplateConfig.canvas_group == canvas_group)
+                ).first()
+                is None
+            )
+            te_type_count = len(
+                session.execute(
+                    select(TemplateConfig)
+                    .where(TemplateConfig.config_type == config_type)
+                    .where(TemplateConfig.canvas_group == canvas_group)
+                ).all()
+            )
+            if duplicate_check is True and te_type_count < 3:
                 session.add(
                     TemplateConfig(
                         config_type=config_type,

--- a/te_canvas/translator.py
+++ b/te_canvas/translator.py
@@ -111,8 +111,11 @@ class Translator:
         """
         Create canvas event from timeedit reservations.
         """
+
+        # There's a 256 character limit on title length in Canvas API.
+        # We truncate to 230 and then add our TAG_TITLE.
         return {
-            "title":         self.__translate_fields(canvas_group, ConfigType.TITLE.value,timeedit_reservation["objects"], TITLE_SEPARATOR) + TAG_TITLE,
+            "title":         self.__translate_fields(canvas_group, ConfigType.TITLE.value,timeedit_reservation["objects"], TITLE_SEPARATOR)[0:230] + TAG_TITLE,
             "location_name": self.__translate_fields(canvas_group, ConfigType.LOCATION.value, timeedit_reservation["objects"], LOCATION_SEPARATOR),
             "description":   self.__translate_fields(canvas_group, ConfigType.DESCRIPTION.value, timeedit_reservation["objects"], DESCRIPTION_SEPARATOR)
                 + f'<br><br><a href="{self.timeedit.reservation_url(timeedit_reservation["id"])}">Edit on TimeEdit</a>',


### PR DESCRIPTION
Canvas API has a 256 char title length limit.
We truncate title then add tag title when creating the title string.

Also, Timeedit API has a maximum of 3 return type fields.
We limit this in our API and return 400 if user tries to set more than 3 fields/te_type.